### PR TITLE
chore: upgrade GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,10 @@ on:
   push:
     branches:
     - master
-    
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     # This job will run on ubuntu virtual machine
@@ -14,7 +17,7 @@ jobs:
     steps:
     
     # Setup Java environment in order to build the Android app.
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v6
     - uses: actions/setup-java@v4.6.0
       with:
         java-version: 11 #'12.x'


### PR DESCRIPTION
## Summary
- upgrade GitHub-hosted JavaScript actions to Node 24-compatible versions
- opt workflows into Node 24 now with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
- keep workflow behavior otherwise unchanged
